### PR TITLE
Well, I tried my hand at adding a setting to toggle notifications in response to issue #53

### DIFF
--- a/src/syrin/components/element/index.svelte
+++ b/src/syrin/components/element/index.svelte
@@ -10,7 +10,7 @@
 
 	// Event handlers
 	function play() {
-		ctx.game.notifyInfo(`SyrinControl | Playing "${element.name}"`);
+		if(utils.notificationsEnabled)ctx.game.notifyInfo(`SyrinControl | Playing "${element.name}"`);
 		ctx.api.playElement(element.id);
 	}
 

--- a/src/syrin/services/utils.ts
+++ b/src/syrin/services/utils.ts
@@ -58,4 +58,8 @@ export class Utils {
 	getSessionId(): string {
 		return this.game.getSetting<string>('sessionId');
 	}
+
+	notificationsEnabled(): boolean {
+		return this.game.getSetting<boolean>('showNotifications');
+	}
 }

--- a/src/syrin/settings.ts
+++ b/src/syrin/settings.ts
@@ -63,6 +63,16 @@ export function initSettings(ctx: Context) {
 		type: Boolean,
 		default: 'false'
 	});
+
+
+	game.registerSetting('showNotifications', {
+		name: 'Show Notifications',
+		hint: 'Uncheck if you don\'t want to see any notification when SyrinControl plays a sound',
+		scope: 'world',
+		config: true,
+		type: Boolean,
+		default: true
+	});
 }
 
 export async function onCloseSettings(ctx: Context) {


### PR DESCRIPTION
Disclaimer: I have not tested this as I have no idea how to get from the code to a working module. I have never before written a module, I have no idea what cypress or svelte are and what they are doing and I only know a bit of Javascript, not Typescript. So this may be utter BS.

Having said that, I felt that issue #53 couldn't be too hard to do. So I had a look at the code and after a little bit of copying, pasteing and adapting, I feel like this could work. 

Likely sources for issues:
- I don't know if utils is loaded when play() is called or if it is even accessible from this svelte file
- showNotifications and notificationsEnabled seem like pretty common identifiers, so there may be some conflict.

In summary, if you reject this pull request I'm not offended in the slightest. But it would be nice if anyone could tell me how to test this, so in the future I might make a usefull pull request.