### PR TITLE
Fixes #85

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -4,7 +4,7 @@ import type { Config } from 'jest';
 import { pathsToModuleNameMapper } from 'ts-jest';
 
 const config: Config = {
-	collectCoverageFrom: ['src/**/*'],
+	collectCoverageFrom: ['src/**/*.{svelte,ts,js}'],
 	coveragePathIgnorePatterns: [
 		'<rootDir>/src/main.ts', // Because execution part is hard to test
 		'<rootDir>/src/services/game.ts', // Because its an implementation detail of foundry, non-testable

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -10,6 +10,39 @@ Object.defineProperty(global, 'Hooks', {
 	}
 });
 
+Object.defineProperty(global, 'foundry', {
+	value: {
+		utils: {
+			flattenObject: (obj: any, _d: number = 0) => {
+				return flattenObject(obj, _d);
+			}
+		}
+	}
+});
+
+function flattenObject(ob: any, _d: number = 0) {
+	var toReturn: any = {};
+	if (_d > 100) {
+		throw new Error('Maximum depth exceeded');
+	}
+
+	for (var i in ob) {
+		if (!ob.hasOwnProperty(i)) continue;
+
+		if (typeof ob[i] == 'object' && ob[i] !== null) {
+			var flatObject = flattenObject(ob[i], _d + 1);
+			for (var x in flatObject) {
+				if (!flatObject.hasOwnProperty(x)) continue;
+
+				toReturn[i + '.' + x] = flatObject[x];
+			}
+		} else {
+			toReturn[i] = ob[i];
+		}
+	}
+	return toReturn;
+}
+
 configure({
 	testIdAttribute: 'data-test'
 });

--- a/src/proxies.ts
+++ b/src/proxies.ts
@@ -10,10 +10,11 @@ function populateContext(ctx: any): Context {
 		ctx = {};
 	}
 	if (ctx.ctx === undefined || ctx.ctx === null) {
-		ctx.ctx = container.resolve(Context);
+		let context = container.resolve(Context);
+		ctx.syrinCtx = () => context;
 		ctx.ctx.utils.warn('Context was undefined. Fixing it!');
 	}
-	return ctx.ctx;
+	return ctx.syrinCtx();
 }
 
 class SyrinAmbientSound extends AmbientSound {
@@ -26,10 +27,11 @@ class SyrinAmbientSound extends AmbientSound {
 
 		const provider = {
 			id: () => this.id,
-			radius: () => this.radius
+			radius: () => this.radius,
+			ctx: () => ctx
 		};
 
-		this.syrin = new AmbientSoundController(data, ctx, provider);
+		this.syrin = new AmbientSoundController(data, provider);
 	}
 
 	override _createSound(): null {
@@ -59,10 +61,11 @@ class SyrinPlaylistSound extends PlaylistSound {
 		const provider = {
 			playing: () => this.playing,
 			id: () => this.id,
-			update: (playing: boolean) => this.update({ playing })
+			update: (playing: boolean) => this.update({ playing }),
+			ctx: () => ctx
 		};
 
-		this.syrin = new PlaylistSoundController(data, ctx, provider);
+		this.syrin = new PlaylistSoundController(data, provider);
 	}
 
 	override async sync(): Promise<void> {
@@ -92,9 +95,10 @@ class SyrinPlaylist extends Playlist {
 
 		const provider = {
 			id: () => this.id,
-			update: (playing: boolean) => this.update({ playing })
+			update: (playing: boolean) => this.update({ playing }),
+			ctx: () => ctx
 		};
-		this.syrin = new PlaylistController(data, ctx, provider);
+		this.syrin = new PlaylistController(data, provider);
 	}
 
 	override async playAll(): Promise<undefined> {
@@ -125,10 +129,10 @@ function handler<
 				return new t(...args);
 			}
 
-			if (args[1] === undefined) {
+			if (args[1] === undefined || args[1] === null) {
 				args[1] = {};
 			}
-			(args[1] as any).ctx = ctx;
+			(args[1] as any).syrinCtx = () => ctx;
 			return new s(...args);
 		}
 	};

--- a/src/proxies.ts
+++ b/src/proxies.ts
@@ -12,7 +12,7 @@ function populateContext(ctx: any): Context {
 	if (ctx.ctx === undefined || ctx.ctx === null) {
 		let context = container.resolve(Context);
 		ctx.syrinCtx = () => context;
-		ctx.ctx.utils.warn('Context was undefined. Fixing it!');
+		context.utils.warn('Context was undefined. Fixing it!');
 	}
 	return ctx.syrinCtx();
 }

--- a/src/sounds/__snapshots__/ambient-sound.spec.ts.snap
+++ b/src/sounds/__snapshots__/ambient-sound.spec.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Ambient sound controller bugs can be flattened 1`] = `
+{
+  "flags.mood": 4321,
+  "flags.type": "mood",
+  "provider.ctx": [Function],
+  "provider.id": [Function],
+  "provider.radius": [Function],
+}
+`;

--- a/src/sounds/__snapshots__/playlist-sound.spec.ts.snap
+++ b/src/sounds/__snapshots__/playlist-sound.spec.ts.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Ambient sound controller bugs can be flattened 1`] = `
+{
+  "flags.mood": 4321,
+  "flags.type": "mood",
+  "provider.ctx": [Function],
+  "provider.id": [Function],
+  "provider.playing": [MockFunction],
+  "provider.update": [MockFunction] {
+    "calls": [
+      [
+        false,
+      ],
+    ],
+    "results": [
+      {
+        "type": "return",
+        "value": undefined,
+      },
+    ],
+  },
+  "unsubscriber": [Function],
+  "wasPlaying": false,
+}
+`;

--- a/src/sounds/__snapshots__/playlist.spec.ts.snap
+++ b/src/sounds/__snapshots__/playlist.spec.ts.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Ambient sound controller bugs can be flattened 1`] = `
+{
+  "flags.soundset": "1234",
+  "provider.ctx": [Function],
+  "provider.id": [Function],
+  "provider.update": [MockFunction] {
+    "calls": [
+      [
+        false,
+      ],
+    ],
+    "results": [
+      {
+        "type": "return",
+        "value": undefined,
+      },
+    ],
+  },
+  "unsubscriber": [Function],
+}
+`;

--- a/src/sounds/ambient-sound.spec.ts
+++ b/src/sounds/ambient-sound.spec.ts
@@ -20,9 +20,10 @@ describe('Ambient sound controller', () => {
 	it('does nothing when player is not active', async () => {
 		const provider = {
 			id: () => '1',
-			radius: () => 10
+			radius: () => 10,
+			ctx: () => mock.ctx
 		};
-		const sound = new AmbientSound({ flags: { syrinscape: flags } }, mock.ctx, provider);
+		const sound = new AmbientSound({ flags: { syrinscape: flags } }, provider);
 
 		mock.raw.getState = jest.fn(() => 'inactive');
 
@@ -34,9 +35,10 @@ describe('Ambient sound controller', () => {
 	it('also does nothing when id is unknown', async () => {
 		const provider = {
 			id: () => null,
-			radius: () => 10
+			radius: () => 10,
+			ctx: () => mock.ctx
 		};
-		const sound = new AmbientSound({ flags: { syrinscape: flags } }, mock.ctx, provider);
+		const sound = new AmbientSound({ flags: { syrinscape: flags } }, provider);
 
 		await sound.sync(true, 1);
 
@@ -47,9 +49,10 @@ describe('Ambient sound controller', () => {
 		const spy = jest.spyOn(mock.ctx.syrin, 'stopAmbientSound');
 		const provider = {
 			id: () => '1',
-			radius: () => 10
+			radius: () => 10,
+			ctx: () => mock.ctx
 		};
-		const sound = new AmbientSound({ flags: { syrinscape: flags } }, mock.ctx, provider);
+		const sound = new AmbientSound({ flags: { syrinscape: flags } }, provider);
 
 		await sound.sync(false, 1);
 
@@ -60,9 +63,10 @@ describe('Ambient sound controller', () => {
 		const spy = jest.spyOn(mock.ctx.syrin, 'playAmbientSound');
 		const provider = {
 			id: () => '1',
-			radius: () => 10
+			radius: () => 10,
+			ctx: () => mock.ctx
 		};
-		const sound = new AmbientSound({ flags: { syrinscape: flags } }, mock.ctx, provider);
+		const sound = new AmbientSound({ flags: { syrinscape: flags } }, provider);
 
 		await sound.sync(true, 1);
 
@@ -78,13 +82,14 @@ describe('Ambient sound controller', () => {
 		const spy = jest.spyOn(mock.ctx.syrin, 'playAmbientSound');
 		const provider = {
 			id: () => '1',
-			radius: () => 10
+			radius: () => 10,
+			ctx: () => mock.ctx
 		};
 		flags = {
 			type: 'element',
 			element: 4321
 		};
-		const sound = new AmbientSound({ flags: { syrinscape: flags } }, mock.ctx, provider);
+		const sound = new AmbientSound({ flags: { syrinscape: flags } }, provider);
 
 		await sound.sync(true, 1);
 
@@ -101,9 +106,10 @@ describe('Ambient sound controller', () => {
 		const spy = jest.spyOn(mock.ctx.syrin, 'playAmbientSound');
 		const provider = {
 			id: () => '1',
-			radius: () => 10
+			radius: () => 10,
+			ctx: () => mock.ctx
 		};
-		const sound = new AmbientSound({ flags: { syrinscape: flags } }, mock.ctx, provider);
+		const sound = new AmbientSound({ flags: { syrinscape: flags } }, provider);
 
 		await sound.sync(true, 1);
 
@@ -112,6 +118,21 @@ describe('Ambient sound controller', () => {
 			volume: 0,
 			userId: '',
 			moodId: 4321
+		});
+	});
+
+	describe('bugs', () => {
+		it('can be flattened', () => {
+			const provider = {
+				id: () => '1',
+				radius: () => 10,
+				ctx: () => mock.ctx
+			};
+			const sound = new AmbientSound({ flags: { syrinscape: flags } }, provider);
+
+			const flattened = foundry.utils.flattenObject(sound);
+
+			expect(flattened).toMatchSnapshot();
 		});
 	});
 });

--- a/src/sounds/ambient-sound.ts
+++ b/src/sounds/ambient-sound.ts
@@ -6,21 +6,20 @@ export type SyrinAmbientSoundFlags = ElementSoundFlags | MoodSoundFlags;
 export interface AmbientSoundProvider {
 	id(): string | null;
 	radius(): number;
+	ctx(): Context;
 }
 export class AmbientSound {
-	ctx: Context;
 	flags: SyrinAmbientSoundFlags;
 	provider: AmbientSoundProvider;
 
-	constructor(data: any, ctx: Context, provider: AmbientSoundProvider) {
-		this.ctx = ctx;
+	constructor(data: any, provider: AmbientSoundProvider) {
 		this.flags = data.flags.syrinscape;
 		this.provider = provider;
-		this.ctx.utils.trace('Creating an ambient sound', { data, flags: this.flags });
+		this.provider.ctx().utils.trace('Creating an ambient sound', { data, flags: this.flags });
 	}
 
 	async sync(isAudible: boolean, volume: number): Promise<void> {
-		if (!this.ctx.api.isPlayerActive()) {
+		if (!this.provider.ctx().api.isPlayerActive()) {
 			return;
 		}
 
@@ -30,13 +29,13 @@ export class AmbientSound {
 		}
 
 		const power = (1.0 - volume) * this.provider.radius();
-		const userId = this.ctx.game.userId() ?? '';
+		const userId = this.provider.ctx().game.userId() ?? '';
 
 		if (isAudible) {
 			switch (this.flags.type) {
 				case 'mood': {
 					const moodId = this.flags.mood;
-					this.ctx.syrin.playAmbientSound(id, {
+					this.provider.ctx().syrin.playAmbientSound(id, {
 						kind: 'mood',
 						volume: power,
 						moodId,
@@ -46,7 +45,7 @@ export class AmbientSound {
 				}
 				case 'element': {
 					const elementId = this.flags.element;
-					this.ctx.syrin.playAmbientSound(id, {
+					this.provider.ctx().syrin.playAmbientSound(id, {
 						kind: 'element',
 						volume: power,
 						elementId,
@@ -56,7 +55,7 @@ export class AmbientSound {
 				}
 			}
 		} else {
-			this.ctx.syrin.stopAmbientSound(id, userId);
+			this.provider.ctx().syrin.stopAmbientSound(id, userId);
 		}
 	}
 }

--- a/src/sounds/playlist-sound.spec.ts
+++ b/src/sounds/playlist-sound.spec.ts
@@ -38,9 +38,10 @@ describe('Ambient sound controller', () => {
 		const provider = {
 			id: () => '1',
 			playing: jest.fn(() => true),
-			update: jest.fn((_playing: boolean) => {})
+			update: jest.fn((_playing: boolean) => {}),
+			ctx: () => mock.ctx
 		};
-		const sound = new PlaylistSound({ flags: { syrinscape: flags } }, mock.ctx, provider);
+		const sound = new PlaylistSound({ flags: { syrinscape: flags } }, provider);
 		const spy = jest.spyOn(sound, 'unsubscriber');
 
 		sound.unsubscribe();
@@ -56,12 +57,13 @@ describe('Ambient sound controller', () => {
 				playing: jest.fn(() => false),
 				update: jest.fn((playing: boolean) => {
 					newPlaying = playing;
-				})
+				}),
+				ctx: () => mock.ctx
 			};
 
 			expect(newPlaying).toBe(false);
 
-			const sound = new PlaylistSound({ flags: { syrinscape: flags } }, mock.ctx, provider);
+			const sound = new PlaylistSound({ flags: { syrinscape: flags } }, provider);
 
 			mock.ctx.stores.nextPlaylistMood.set(4321);
 
@@ -82,9 +84,10 @@ describe('Ambient sound controller', () => {
 			const provider = {
 				id: () => '1',
 				playing: jest.fn(() => true),
-				update: jest.fn((_playing: boolean) => {})
+				update: jest.fn((_playing: boolean) => {}),
+				ctx: () => mock.ctx
 			};
-			const sound = new PlaylistSound({ flags: { syrinscape: flags } }, mock.ctx, provider);
+			const sound = new PlaylistSound({ flags: { syrinscape: flags } }, provider);
 
 			mock.raw.getState = jest.fn(() => 'inactive');
 
@@ -98,9 +101,10 @@ describe('Ambient sound controller', () => {
 			const provider = {
 				id: () => '1',
 				playing: jest.fn(() => true),
-				update: jest.fn((_playing: boolean) => {})
+				update: jest.fn((_playing: boolean) => {}),
+				ctx: () => mock.ctx
 			};
-			const sound = new PlaylistSound({ flags: { syrinscape: flags } }, mock.ctx, provider);
+			const sound = new PlaylistSound({ flags: { syrinscape: flags } }, provider);
 
 			await sound.sync();
 
@@ -113,9 +117,10 @@ describe('Ambient sound controller', () => {
 			const provider = {
 				id: () => '1',
 				playing: jest.fn(() => true),
-				update: jest.fn((_playing: boolean) => {})
+				update: jest.fn((_playing: boolean) => {}),
+				ctx: () => mock.ctx
 			};
-			const sound = new PlaylistSound({ flags: { syrinscape: flags } }, mock.ctx, provider);
+			const sound = new PlaylistSound({ flags: { syrinscape: flags } }, provider);
 			sound.wasPlaying = true;
 
 			await sound.sync();
@@ -130,9 +135,10 @@ describe('Ambient sound controller', () => {
 			const provider = {
 				id: () => '1',
 				playing: jest.fn(() => false),
-				update: jest.fn((_playing: boolean) => {})
+				update: jest.fn((_playing: boolean) => {}),
+				ctx: () => mock.ctx
 			};
-			const sound = new PlaylistSound({ flags: { syrinscape: flags } }, mock.ctx, provider);
+			const sound = new PlaylistSound({ flags: { syrinscape: flags } }, provider);
 			sound.wasPlaying = true;
 
 			await sound.sync();
@@ -148,9 +154,10 @@ describe('Ambient sound controller', () => {
 			const provider = {
 				id: () => '1',
 				playing: jest.fn(() => true),
-				update: jest.fn((_playing: boolean) => {})
+				update: jest.fn((_playing: boolean) => {}),
+				ctx: () => mock.ctx
 			};
-			const sound = new PlaylistSound({ flags: { syrinscape: flags } }, mock.ctx, provider);
+			const sound = new PlaylistSound({ flags: { syrinscape: flags } }, provider);
 			sound.wasPlaying = false;
 
 			await sound.sync();
@@ -159,6 +166,21 @@ describe('Ambient sound controller', () => {
 			expect(spySet).toBeCalledWith(4321);
 
 			expect(spyStop).not.toBeCalled();
+		});
+	});
+	describe('bugs', () => {
+		it('can be flattened', () => {
+			const provider = {
+				id: () => '1',
+				playing: jest.fn(() => true),
+				update: jest.fn((_playing: boolean) => {}),
+				ctx: () => mock.ctx
+			};
+			const sound = new PlaylistSound({ flags: { syrinscape: flags } }, provider);
+
+			const flattened = foundry.utils.flattenObject(sound);
+
+			expect(flattened).toMatchSnapshot();
 		});
 	});
 });

--- a/src/sounds/playlist-sound.ts
+++ b/src/sounds/playlist-sound.ts
@@ -8,17 +8,16 @@ export interface PlaylistSoundProvider {
 	playing(): boolean;
 	id(): null | string;
 	update(playing: boolean): void;
+	ctx(): Context;
 }
 
 export class PlaylistSound {
-	ctx: Context;
 	flags: SyrinPlaylistSoundFlags;
 	unsubscriber?: Unsubscriber;
 	wasPlaying: boolean;
 	provider: PlaylistSoundProvider;
 
-	constructor(data: any, ctx: Context, provider: PlaylistSoundProvider) {
-		this.ctx = ctx;
+	constructor(data: any, provider: PlaylistSoundProvider) {
 		this.flags = data.flags.syrinscape;
 		this.wasPlaying = false;
 		this.provider = provider;
@@ -27,9 +26,9 @@ export class PlaylistSound {
 	}
 
 	handleSubscribtion() {
-		if (this.flags.type === 'mood' && this.ctx.game.isGM()) {
+		if (this.flags.type === 'mood' && this.provider.ctx().game.isGM()) {
 			const moodId = this.flags.mood;
-			this.unsubscriber = this.ctx.stores.currentlyPlaying.subscribe((playing) => {
+			this.unsubscriber = this.provider.ctx().stores.currentlyPlaying.subscribe((playing) => {
 				const mood = playing?.mood;
 				if (this.provider.id() !== null) {
 					const playing = mood?.id === moodId;
@@ -45,7 +44,7 @@ export class PlaylistSound {
 	}
 
 	async sync(): Promise<void> {
-		if (!this.ctx.api.isPlayerActive() || !this.ctx.game.isGM()) {
+		if (!this.provider.ctx().api.isPlayerActive() || !this.provider.ctx().game.isGM()) {
 			return;
 		}
 
@@ -53,9 +52,9 @@ export class PlaylistSound {
 			switch (this.flags.type) {
 				case 'mood': {
 					if (this.provider.playing()) {
-						this.ctx.syrin.setMood(this.flags.mood);
+						this.provider.ctx().syrin.setMood(this.flags.mood);
 					} else {
-						this.ctx.syrin.stopAll();
+						this.provider.ctx().syrin.stopAll();
 					}
 					break;
 				}

--- a/src/sounds/playlist.spec.ts
+++ b/src/sounds/playlist.spec.ts
@@ -36,9 +36,10 @@ describe('Ambient sound controller', () => {
 	it('calls unsubscriber', () => {
 		const provider = {
 			id: () => '1',
-			update: jest.fn((_playing: boolean) => {})
+			update: jest.fn((_playing: boolean) => {}),
+			ctx: () => mock.ctx
 		};
-		const sound = new Playlist({ flags: { syrinscape: flags } }, mock.ctx, provider);
+		const sound = new Playlist({ flags: { syrinscape: flags } }, provider);
 		const spy = jest.spyOn(sound, 'unsubscriber');
 
 		sound.unsubscribe();
@@ -49,9 +50,10 @@ describe('Ambient sound controller', () => {
 	it('stops all', () => {
 		const provider = {
 			id: () => '1',
-			update: jest.fn((_playing: boolean) => {})
+			update: jest.fn((_playing: boolean) => {}),
+			ctx: () => mock.ctx
 		};
-		const sound = new Playlist({ flags: { syrinscape: flags } }, mock.ctx, provider);
+		const sound = new Playlist({ flags: { syrinscape: flags } }, provider);
 		const spy = jest.spyOn(mock.ctx.syrin, 'stopAll');
 
 		sound.stopAll();
@@ -66,12 +68,13 @@ describe('Ambient sound controller', () => {
 				id: () => '1',
 				update: jest.fn((playing: boolean) => {
 					newPlaying = playing;
-				})
+				}),
+				ctx: () => mock.ctx
 			};
 
 			expect(newPlaying).toBe(false);
 
-			const sound = new Playlist({ flags: { syrinscape: flags } }, mock.ctx, provider);
+			const sound = new Playlist({ flags: { syrinscape: flags } }, provider);
 
 			mock.ctx.stores.nextPlaylistMood.set(4321);
 
@@ -84,6 +87,21 @@ describe('Ambient sound controller', () => {
 			expect(newPlaying).toBe(true);
 
 			sound.unsubscribe();
+		});
+	});
+
+	describe('bugs', () => {
+		it('can be flattened', () => {
+			const provider = {
+				id: () => '1',
+				update: jest.fn((_playing: boolean) => {}),
+				ctx: () => mock.ctx
+			};
+			const sound = new Playlist({ flags: { syrinscape: flags } }, provider);
+
+			const flattened = foundry.utils.flattenObject(sound);
+
+			expect(flattened).toMatchSnapshot();
 		});
 	});
 });

--- a/src/sounds/playlist.ts
+++ b/src/sounds/playlist.ts
@@ -4,6 +4,7 @@ import { Unsubscriber } from 'svelte/store';
 export interface PlaylistProvider {
 	update(playing: boolean): void;
 	id(): null | string;
+	ctx(): Context;
 }
 
 export interface SyrinPlaylistFlags {
@@ -11,13 +12,11 @@ export interface SyrinPlaylistFlags {
 }
 
 export class Playlist {
-	ctx: Context;
 	flags: SyrinPlaylistFlags;
 	unsubscriber?: Unsubscriber;
 	provider: PlaylistProvider;
 
-	constructor(data: any, ctx: Context, provider: PlaylistProvider) {
-		this.ctx = ctx;
+	constructor(data: any, provider: PlaylistProvider) {
 		this.flags = data.flags.syrinscape;
 		this.provider = provider;
 
@@ -25,11 +24,11 @@ export class Playlist {
 	}
 
 	handleSubscribtion() {
-		this.unsubscriber = this.ctx.stores.currentlyPlaying.subscribe((playing) => {
+		this.unsubscriber = this.provider.ctx().stores.currentlyPlaying.subscribe((playing) => {
 			const soundset = playing?.soundset;
 			if (this.provider.id() !== null) {
 				const playing = soundset?.id === this.flags.soundset;
-				if (this.ctx.game.isGM()) {
+				if (this.provider.ctx().game.isGM()) {
 					this.provider.update(playing);
 				}
 			}
@@ -37,7 +36,7 @@ export class Playlist {
 	}
 
 	stopAll() {
-		this.ctx.syrin.stopAll();
+		this.provider.ctx().syrin.stopAll();
 	}
 
 	unsubscribe() {


### PR DESCRIPTION
## Context
Module prevented Saving Changes in the Grid Configuration Tool. This is a fix.

## What has been changed and why

The way how we store information about the syrinControl context in the scene.
By hiding it behind the closure, we no longer hit the infinite loop in the Foundry's `flattenObject` utils function.


## Resolves
Fixes #85

## Blocked by

## Thigs needed to close this PR:

- [x] Tested manually
- [x] Wrote e2e test - no need
- [x] Wrote unit tests
- [x] Wrote documentation - no need
