### PR TITLE
Add two new buttons to Soundsets Importer window

### DIFF
--- a/public/languages/en.json
+++ b/public/languages/en.json
@@ -50,6 +50,7 @@
 			"elements": "Soundset Elements",
 			"createdMacro": "Created macro \"{macroName}\"",
 			"createdFolder": "Created macro folder \"{folderName}\"",
+			"idCopiedToClipboard": "Mood Id copied to clipboard : \"{id}\"",
 			"collapse": "Collapse: ",
 			"expand": "Expand: ",
 			"removeSelection": "Remove selection: ",

--- a/public/languages/en.json
+++ b/public/languages/en.json
@@ -60,7 +60,8 @@
 			"stopMood": "Stop Mood",
 			"playElement": "Play: {elementName}",
 			"createMacro": "Create Macro",
-			"createPlaylist": "Create Playlist"
+			"createPlaylist": "Create Playlist",
+			"copyIdToClipboard": "Copy ID to Clipboard"
 		},
 		"elements": {
 			"zeroFound": "No elements found"

--- a/public/languages/pl.json
+++ b/public/languages/pl.json
@@ -59,7 +59,8 @@
 			"playElement": "Graj: {elementName}",
 			"stopMood": "Zatrzymaj nastrój",
 			"createMacro": "Utwórz makro",
-			"createPlaylist": "Utwórz playlistę"
+			"createPlaylist": "Utwórz playlistę",
+			"copyIdToClipboard": "Copy ID to Clipboard"
 		},
 		"elements": {
 			"zeroFound": "Brak elementów"

--- a/src/components/SimpleButton.svelte
+++ b/src/components/SimpleButton.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	export let icon: string;
+	export let title: string;
+</script>
+
+<span role="button" class="syrin-control" {title} on:click on:keypress>
+	<i class="fas fa-{icon}" />
+</span>
+
+<style>
+	.syrin-control {
+		display: inline;
+		margin: 2px;
+		vertical-align: middle;
+	}
+
+	.syrin-control i {
+		display: inline;
+		vertical-align: middle;
+	}
+</style>

--- a/src/components/importer/Mood.svelte
+++ b/src/components/importer/Mood.svelte
@@ -50,6 +50,7 @@
 
 	function copyMoodIdToClipboard() {
 		navigator.clipboard.writeText(mood.id.toString());
+		ctx.game.notifyInfo('importer.idCopiedToClipboard', { id: mood.id });
 	}
 </script>
 

--- a/src/components/importer/Mood.svelte
+++ b/src/components/importer/Mood.svelte
@@ -2,6 +2,7 @@
 	import type { CurrentlyPlaying, Mood, Soundset } from '@/models';
 	import Context from '@/services/context';
 	import Toggable from '@/components/Toggable.svelte';
+	import SimpleButton from '@/components/SimpleButton.svelte';
 
 	// Context
 	const ctx = Context();
@@ -40,6 +41,16 @@
 			ctx.syrin.setMood(mood.id);
 		}
 	}
+
+	async function createMoodMacro() {
+		let macro = await ctx.game.createMoodMacro(mood, '');
+		ctx.utils.trace('Element | Macro = ', { macro });
+		ctx.game.notifyInfo('importer.createdMacro', { macroName: mood.name });
+	}
+
+	function copyMoodIdToClipboard() {
+		navigator.clipboard.writeText(mood.id.toString());
+	}
 </script>
 
 <tr class="mood" data-test="syrin-mood-row">
@@ -56,6 +67,16 @@
 		</span>
 	</td>
 	<td class="actions-cell">
+		<SimpleButton
+			on:click={copyMoodIdToClipboard}
+			title={ctx.game.localize('commands.copyIdToClipboard')}
+			icon="copy"
+		/>
+		<SimpleButton
+			on:click={createMoodMacro}
+			title={ctx.game.localize('commands.createMacro')}
+			icon="terminal"
+		/>
 		<Toggable
 			on:click={onPlayMood}
 			toggled={isPlaying}


### PR DESCRIPTION
Changes:
- Added a button to copy the ID of a mood to the clipboard
- Added a button to create a macro to play a mood

https://github.com/frondeus/fvtt-syrin-control/assets/7666672/157cf228-358d-43a0-8d54-a4c37f7f840b

